### PR TITLE
Refactoring contexts and fixing bug in nested JSON

### DIFF
--- a/functests/xml-tests.yaml
+++ b/functests/xml-tests.yaml
@@ -524,3 +524,49 @@ tests:
           </form>
         </delimited>
       </unit>
+
+  - name: "Bug: inside-form label detection - IF"
+    command: "{command} --format xml --indent 2"
+    input: |
+      if x:
+        y
+      endif
+    expected_output: |
+      <unit>
+        <form syntax="surround">
+          <part keyword="if">
+            <identifier name="x" />
+          </part>
+          <part keyword="_">
+            <identifier name="y" />
+          </part>
+        </form>
+      </unit>
+
+  - name: "Bug: inside-form label detection - JSON expression"
+    command: "{command} --format xml --indent 2"
+    input: |
+      foo
+        { 
+          a : b,
+          x : y
+        }
+      endfoo
+    expected_output: |
+      <unit>
+        <form syntax="surround">
+          <part keyword="foo">
+            <delimited kind="braces" separator="comma">
+              <operator name=":" syntax="infix">
+                <identifier name="a" />
+                <identifier name="b" />
+              </operator>
+              <operator name=":" syntax="infix">
+                <identifier name="x" />
+                <identifier name="y" />
+              </operator>
+            </delimited>
+          </part>
+        </form>
+      </unit>
+

--- a/mg/context.go
+++ b/mg/context.go
@@ -1,0 +1,26 @@
+package mg
+
+type Context struct {
+	AcceptNewline bool
+	InsideForm    bool
+}
+
+func makeContext() Context {
+	return Context{AcceptNewline: false}
+}
+
+func (c Context) setInsideForm(insideForm bool) Context {
+	c.AcceptNewline = insideForm
+	c.InsideForm = insideForm
+	return c
+}
+
+func (c Context) setAcceptNewline(acceptNewline bool) Context {
+	c.AcceptNewline = acceptNewline
+	return c
+}
+
+func (c Context) setInsideBraces(insideBraces bool) Context {
+	c.AcceptNewline = insideBraces
+	return c.setInsideForm(false).setAcceptNewline(insideBraces)
+}

--- a/mg/parser_test.go
+++ b/mg/parser_test.go
@@ -29,7 +29,7 @@ func TestParsePrefix0(t *testing.T) {
 		t.Fatalf("getParser error: %v", err)
 		return
 	}
-	cxt := Context{false, false}
+	cxt := makeContext()
 
 	// Act
 	node, err := parser.doReadPrimaryExpr(cxt)
@@ -65,7 +65,7 @@ func TestParsePrefix1(t *testing.T) {
 		t.Fatalf("getParser error: %v", err)
 		return
 	}
-	cxt := Context{false, false}
+	cxt := makeContext()
 
 	// Act
 	node, err := parser.doReadPrimaryExpr(cxt)
@@ -105,7 +105,7 @@ func TestParsePrefix2NoComma(t *testing.T) {
 		t.Fatalf("getParser error: %v", err)
 		return
 	}
-	cxt := Context{false, false}
+	cxt := makeContext()
 
 	// Act
 	node, err := parser.doReadPrimaryExpr(cxt)


### PR DESCRIPTION
This refactors the code associated with Context to make it more readable and, in the process, fixes an issue concerned with handling `:` inside of bracketed expressions inside forms.