### PR TITLE
[docs] Add to the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Following the style in https://keepachangelog.com/en/1.0.0/
   work in the same way as `x-2`. Previous you would have needed to add
   spaces.
 
+- The `^` character is now allowed in operators. It was always meant to be
+  part of the base character set, analogous to the C language.
+
 ## [0.5.5] Bug Fixes
 
 ### Fixed


### PR DESCRIPTION
This should have been bundled with the previous commits. However, I did not realise I had no branch protection on main (after the repo split), so stuff was accidentally pushed to `main`. Now fixed.